### PR TITLE
Fix search bar caret auto-selection on first character

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -53,10 +53,10 @@ function CommandDialog({
   );
 }
 
-function CommandInput({
-  className,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+const CommandInput = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Input>,
+  React.ComponentProps<typeof CommandPrimitive.Input>
+>(({ className, ...props }, ref) => {
   return (
     <div
       data-slot="command-input-wrapper"
@@ -64,6 +64,7 @@ function CommandInput({
     >
       <SearchIcon className="size-4 shrink-0 opacity-50" />
       <CommandPrimitive.Input
+        ref={ref}
         data-slot="command-input"
         className={cn(
           'placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
@@ -73,7 +74,9 @@ function CommandInput({
       />
     </div>
   );
-}
+});
+
+CommandInput.displayName = CommandPrimitive.Input.displayName;
 
 function CommandList({
   className,


### PR DESCRIPTION
# Summary

- Fixes the command palette search input selecting the entire value after the first keystroke, which caused the second character to overwrite the first.
- Forwards refs through `CommandInput`, and on the search bar side only collapses the selection when the whole string is highlighted, keeping normal cursor behavior intact.

## Related Issues / Tickets

- Closes #9

## Contributor info

- LinkedIn profile: https://www.linkedin.com/in/muneer320 
<sub>Not a woman, but will be there if I can be of help!</sub>

## Type of change

- [x] Fix (non-breaking change that fixes an issue)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Refactor (no functional change)
- [ ] Chore/Docs/Build
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How to Test

```bash
npm install            # ensure dependencies (including typescript) are present
npm run dev            # start the Next.js dev server
```

1. Visit http://localhost:3000.
2. Click the search bar and type two characters, the first character should remain, and the second should append.
3. Open the search dialog, repeat the typing test, then close and reopen to confirm the behavior persists.

## Screenshots / Recordings

_Not Needed here_

## Checklist

- [x] I ran the app locally and verified the change
- [ ] I added/updated tests as needed
- [ ] I updated documentation (README, comments, or storybook) as needed
- [ ] I updated environment docs if env vars changed
- [x] No sensitive info (keys, tokens) is committed
- [ ] Database migration required (see “Database Migration” section)

## Breaking Changes

_None._

## Database Migration

_Not applicable._

## Deployment Notes

_No special steps required._

## Environment Changes

_No changes._

## Additional Context

- The root cause was cmdk focusing the search field with the entire string selected after the first keystroke; the ref-based helpers now collapse that selection only when it’s unintended, preserving normal editing.
