### PR TITLE
feat: transform facility names from uppercase to sentence case

### DIFF
--- a/src/components/FacilityCard.tsx
+++ b/src/components/FacilityCard.tsx
@@ -6,7 +6,7 @@ import OpenStatus from '@/components/OpenStatus';
 import OperatingHours from '@/components/OperatingHours';
 import { Badge } from '@/components/ui/badge';
 import { calculateDistance } from '@/lib/utils';
-import { skipTrimToSentenceCase } from '@/utils/text';
+import { transformToSentenceCase } from '@/utils/text';
 import { bottleBaby } from '@lucide/lab';
 import AccessibleIcon from '@mui/icons-material/Accessible';
 import BabyChangingStationIcon from '@mui/icons-material/BabyChangingStation';
@@ -64,7 +64,7 @@ const FacilityCard: React.FC<FacilityCardProps> = ({ location, facility, facilit
           <div className="flex items-center gap-2">
             <h2>
               {
-                skipTrimToSentenceCase(location.building
+                transformToSentenceCase(location.building
                   ? location.building
                   : location.block
                     ? `${location.block} ${location.road}`

--- a/src/components/FacilityCard.tsx
+++ b/src/components/FacilityCard.tsx
@@ -6,7 +6,7 @@ import OpenStatus from '@/components/OpenStatus';
 import OperatingHours from '@/components/OperatingHours';
 import { Badge } from '@/components/ui/badge';
 import { calculateDistance } from '@/lib/utils';
-import { transformToSentenceCase } from '@/utils/text';
+import { capitalizeFirstAlphabeticChar, transformToSentenceCase } from '@/utils/text';
 import { bottleBaby } from '@lucide/lab';
 import AccessibleIcon from '@mui/icons-material/Accessible';
 import BabyChangingStationIcon from '@mui/icons-material/BabyChangingStation';
@@ -64,7 +64,7 @@ const FacilityCard: React.FC<FacilityCardProps> = ({ location, facility, facilit
           <div className="flex items-center gap-2">
             <h2>
               {
-                transformToSentenceCase(location.building
+                capitalizeFirstAlphabeticChar(location.building
                   ? location.building
                   : location.block
                     ? `${location.block} ${location.road}`
@@ -77,7 +77,7 @@ const FacilityCard: React.FC<FacilityCardProps> = ({ location, facility, facilit
             )}
           </div>
           <div className="text-black italic line-clamp-2">
-            {facility.description || ''}
+            {transformToSentenceCase(facility.description || '')}
           </div>
 
           <div className="flex items-center gap-2 text-gray-600 text-sm">

--- a/src/components/FacilityCard.tsx
+++ b/src/components/FacilityCard.tsx
@@ -6,6 +6,7 @@ import OpenStatus from '@/components/OpenStatus';
 import OperatingHours from '@/components/OperatingHours';
 import { Badge } from '@/components/ui/badge';
 import { calculateDistance } from '@/lib/utils';
+import { skipTrimToSentenceCase } from '@/utils/text';
 import { bottleBaby } from '@lucide/lab';
 import AccessibleIcon from '@mui/icons-material/Accessible';
 import BabyChangingStationIcon from '@mui/icons-material/BabyChangingStation';
@@ -63,11 +64,11 @@ const FacilityCard: React.FC<FacilityCardProps> = ({ location, facility, facilit
           <div className="flex items-center gap-2">
             <h2>
               {
-                location.building
+                skipTrimToSentenceCase(location.building
                   ? location.building
                   : location.block
                     ? `${location.block} ${location.road}`
-                    : location.address
+                    : location.address)
               }
             </h2>
             {facility.floor && <Badge>{facility.floor}</Badge>}

--- a/src/utils/text.test.ts
+++ b/src/utils/text.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { skipTrimToSentenceCase, toSentenceCase } from './text';
+
+describe('Text transformation utilities', () => {
+  describe('toSentenceCase', () => {
+    const cases = [
+      { input: 'ION ORCHARD MALL', expected: 'Ion orchard mall' },
+      { input: 'FAR EAST PLAZA', expected: 'Far east plaza' },
+      { input: 'MANDARIN GALLERY', expected: 'Mandarin gallery' },
+    ];
+
+    it('correctly transforms strings to sentence case', () => {
+      cases.forEach(({ input, expected }) => {
+        expect(toSentenceCase(input)).toBe(expected);
+      });
+    });
+  });
+
+  describe('skipTrimToSentenceCase', () => {
+    const normalCases = [
+      { input: 'ION ORCHARD MALL', expected: 'Ion orchard mall' },
+      { input: 'FAR EAST PLAZA', expected: 'Far east plaza' },
+      { input: 'MANDARIN GALLERY', expected: 'Mandarin gallery' },
+    ];
+
+    const edgeCases = [
+      { input: '', expected: '' },
+      { input: 'A', expected: 'A' },
+      { input: 'b', expected: 'B' },
+      { input: '123 MAIN STREET', expected: '123 Main street' },
+      { input: 'mIXed CaSe StRiNg', expected: 'Mixed case string' },
+      { input: '   LEADING AND TRAILING SPACES   ', expected: 'Leading and trailing spaces' },
+      { input: 'SPECIAL CHARACTERS !@#$', expected: 'Special characters !@#$' },
+      { input: '313@ORCHARD', expected: '313@Orchard' },
+    ];
+
+    it('correctly transforms normal cases to sentence case', () => {
+      normalCases.forEach(({ input, expected }) => {
+        expect(skipTrimToSentenceCase(input)).toBe(expected);
+      });
+    });
+
+    it('correctly handles edge cases', () => {
+      edgeCases.forEach(({ input, expected }) => {
+        expect(skipTrimToSentenceCase(input)).toBe(expected);
+      });
+    });
+  });
+});

--- a/src/utils/text.test.ts
+++ b/src/utils/text.test.ts
@@ -1,21 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { skipTrimToSentenceCase, toSentenceCase } from './text';
+import { transformToSentenceCase } from './text';
 
 describe('Text transformation utilities', () => {
-  describe('toSentenceCase', () => {
-    const cases = [
-      { input: 'ION ORCHARD MALL', expected: 'Ion orchard mall' },
-      { input: 'FAR EAST PLAZA', expected: 'Far east plaza' },
-      { input: 'MANDARIN GALLERY', expected: 'Mandarin gallery' },
-    ];
-
-    it('correctly transforms strings to sentence case', () => {
-      cases.forEach(({ input, expected }) => {
-        expect(toSentenceCase(input)).toBe(expected);
-      });
-    });
-  });
-
   describe('skipTrimToSentenceCase', () => {
     const normalCases = [
       { input: 'ION ORCHARD MALL', expected: 'Ion orchard mall' },
@@ -36,13 +22,13 @@ describe('Text transformation utilities', () => {
 
     it('correctly transforms normal cases to sentence case', () => {
       normalCases.forEach(({ input, expected }) => {
-        expect(skipTrimToSentenceCase(input)).toBe(expected);
+        expect(transformToSentenceCase(input)).toBe(expected);
       });
     });
 
     it('correctly handles edge cases', () => {
       edgeCases.forEach(({ input, expected }) => {
-        expect(skipTrimToSentenceCase(input)).toBe(expected);
+        expect(transformToSentenceCase(input)).toBe(expected);
       });
     });
   });

--- a/src/utils/text.test.ts
+++ b/src/utils/text.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { transformToSentenceCase } from './text';
+import { capitalizeFirstAlphabeticChar, transformToSentenceCase } from './text';
 
 describe('Text transformation utilities', () => {
   describe('when text is not sentence case', () => {
@@ -55,6 +55,57 @@ describe('Text transformation utilities', () => {
         it('should trim the leading and trailing spaces', () => {
           expect(transformToSentenceCase('   LEADING AND TRAILING SPACES   ')).toBe('Leading and trailing spaces');
         });
+      });
+    });
+  });
+
+  describe('when capitalizing each word', () => {
+    describe('when input contains multiple words', () => {
+      it('should capitalize the first alphabetic character of each word', () => {
+        expect(capitalizeFirstAlphabeticChar('hello world')).toBe('Hello World');
+        expect(capitalizeFirstAlphabeticChar('ion orchard mall')).toBe('Ion Orchard Mall');
+      });
+
+      it('should capitalize the first alphabetic character of each word and lowercase the rest', () => {
+        expect(capitalizeFirstAlphabeticChar('hello WORLD')).toBe('Hello World');
+        expect(capitalizeFirstAlphabeticChar('mIXed CaSe')).toBe('Mixed Case');
+      });
+    });
+
+    describe('when input is empty or single character', () => {
+      it('should return empty string for empty input', () => {
+        expect(capitalizeFirstAlphabeticChar('')).toBe('');
+      });
+
+      it('should capitalize single lowercase letter', () => {
+        expect(capitalizeFirstAlphabeticChar('a')).toBe('A');
+      });
+
+      it('should preserve single uppercase letter', () => {
+        expect(capitalizeFirstAlphabeticChar('A')).toBe('A');
+      });
+    });
+
+    describe('when input contains special characters', () => {
+      it('should preserve leading numbers and capitalize first alphabetic character', () => {
+        expect(capitalizeFirstAlphabeticChar('123abc')).toBe('123Abc');
+        expect(capitalizeFirstAlphabeticChar('123 main street')).toBe('123 Main Street');
+      });
+
+      it('should handle words starting with special characters', () => {
+        expect(capitalizeFirstAlphabeticChar('313@orchard')).toBe('313@Orchard');
+        expect(capitalizeFirstAlphabeticChar('@hello #world')).toBe('@Hello #World');
+      });
+
+      it('should preserve special characters throughout', () => {
+        expect(capitalizeFirstAlphabeticChar('hello!world')).toBe('Hello!world');
+      });
+    });
+
+    describe('when input has no alphabetic characters', () => {
+      it('should return the string unchanged', () => {
+        expect(capitalizeFirstAlphabeticChar('123')).toBe('123');
+        expect(capitalizeFirstAlphabeticChar('@#$')).toBe('@#$');
       });
     });
   });

--- a/src/utils/text.test.ts
+++ b/src/utils/text.test.ts
@@ -2,33 +2,59 @@ import { describe, expect, it } from 'vitest';
 import { transformToSentenceCase } from './text';
 
 describe('Text transformation utilities', () => {
-  describe('skipTrimToSentenceCase', () => {
-    const normalCases = [
-      { input: 'ION ORCHARD MALL', expected: 'Ion orchard mall' },
-      { input: 'FAR EAST PLAZA', expected: 'Far east plaza' },
-      { input: 'MANDARIN GALLERY', expected: 'Mandarin gallery' },
-    ];
+  describe('when text is not sentence case', () => {
+    describe('when input is normal uppercase text', () => {
+      const upperCases = [
+        { input: 'ION ORCHARD MALL', expected: 'Ion orchard mall' },
+        { input: 'FAR EAST PLAZA', expected: 'Far east plaza' },
+        { input: 'MANDARIN GALLERY', expected: 'Mandarin gallery' },
+      ];
 
-    const edgeCases = [
-      { input: '', expected: '' },
-      { input: 'A', expected: 'A' },
-      { input: 'b', expected: 'B' },
-      { input: '123 MAIN STREET', expected: '123 Main street' },
-      { input: 'mIXed CaSe StRiNg', expected: 'Mixed case string' },
-      { input: '   LEADING AND TRAILING SPACES   ', expected: 'Leading and trailing spaces' },
-      { input: 'SPECIAL CHARACTERS !@#$', expected: 'Special characters !@#$' },
-      { input: '313@ORCHARD', expected: '313@Orchard' },
-    ];
-
-    it('correctly transforms normal cases to sentence case', () => {
-      normalCases.forEach(({ input, expected }) => {
-        expect(transformToSentenceCase(input)).toBe(expected);
+      it('should change uppercase phrase to sentence case', () => {
+        upperCases.forEach(({ input, expected }) => {
+          expect(transformToSentenceCase(input)).toBe(expected);
+        });
       });
     });
 
-    it('correctly handles edge cases', () => {
-      edgeCases.forEach(({ input, expected }) => {
-        expect(transformToSentenceCase(input)).toBe(expected);
+    describe('when input has mixed case', () => {
+      it('should change the text to sentence case', () => {
+        expect(transformToSentenceCase('mIXed CaSe StRiNg')).toBe('Mixed case string');
+      });
+    });
+
+    describe('when input is empty or single character', () => {
+      it('should return empty string for empty input', () => {
+        expect(transformToSentenceCase('')).toBe('');
+      });
+
+      it('should perserve single uppercase letter', () => {
+        expect(transformToSentenceCase('A')).toBe('A');
+      });
+
+      it('should capitalize single lowercase letter', () => {
+        expect(transformToSentenceCase('b')).toBe('B');
+      });
+    });
+
+    describe('when input contains special characters', () => {
+      describe('when input starts with numbers or special characters', () => {
+        it('should perserve them and change the rest of the text to sentence case', () => {
+          expect(transformToSentenceCase('123 MAIN STREET')).toBe('123 Main street');
+          expect(transformToSentenceCase('313@ORCHARD')).toBe('313@Orchard');
+        });
+      });
+
+      describe('when special characters appear after text', () => {
+        it('should perserve them', () => {
+          expect(transformToSentenceCase('SPECIAL CHARACTERS !@#$')).toBe('Special characters !@#$');
+        });
+      });
+
+      describe('when input has extra whitespace at the beginning or/and end', () => {
+        it('should trim the leading and trailing spaces', () => {
+          expect(transformToSentenceCase('   LEADING AND TRAILING SPACES   ')).toBe('Leading and trailing spaces');
+        });
       });
     });
   });

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -19,7 +19,5 @@ export const skipTrimToSentenceCase = (str: string): string => {
   if (firstCharIndex === -1) {
     return str;
   }
-  return str.slice(0, firstCharIndex)
-    + str.charAt(firstCharIndex).toUpperCase()
-    + str.slice(firstCharIndex + 1).toLowerCase();
+  return str.slice(0, firstCharIndex) + toSentenceCase(str.slice(firstCharIndex));
 };

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -9,7 +9,7 @@
 
 export const transformToSentenceCase = (str: string): string => {
   if (!str) {
-    return str;
+    return '';
   }
   str = str.trim();
   const firstCharIndex = str.search(/[a-z]/i);

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -1,4 +1,20 @@
 /**
+ * Capitalize the first alphabetic character of each word and lowercase the rest.
+ */
+export const capitalizeFirstAlphabeticChar = (str: string): string => {
+  if (!str) {
+    return '';
+  }
+  return str.split(' ').map((word) => {
+    const firstCharIndex = word.search(/[a-z]/i);
+    if (firstCharIndex === -1) {
+      return word;
+    }
+    return word.slice(0, firstCharIndex) + word.charAt(firstCharIndex).toUpperCase() + word.slice(firstCharIndex + 1).toLowerCase();
+  }).join(' ');
+};
+
+/**
  * Convert a string to sentence case:
  * - trims whitespace
  * - uppercases the first alphabetic character and lowercases following letters

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -1,0 +1,25 @@
+/**
+ * Converts a string to sentence case.
+ * @param str the input string
+ * @returns the string in sentence case
+ */
+export const toSentenceCase = (str: string): string => {
+  if (!str) {
+    return str;
+  }
+  return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
+};
+
+export const skipTrimToSentenceCase = (str: string): string => {
+  if (!str) {
+    return str;
+  }
+  str = str.trim();
+  const firstCharIndex = str.search(/[a-z]/i);
+  if (firstCharIndex === -1) {
+    return str;
+  }
+  return str.slice(0, firstCharIndex)
+    + str.charAt(firstCharIndex).toUpperCase()
+    + str.slice(firstCharIndex + 1).toLowerCase();
+};

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -1,16 +1,13 @@
 /**
- * Converts a string to sentence case.
- * @param str the input string
- * @returns the string in sentence case
+ * Convert a string to sentence case:
+ * - trims whitespace
+ * - uppercases the first alphabetic character and lowercases following letters
+ * - preserves leading non-letter characters; returns trimmed string if no letters
+ *
+ * Note: internal acronyms/mixed-case words will be lowercased (e.g. "NASA" -> "Nasa").
  */
-export const toSentenceCase = (str: string): string => {
-  if (!str) {
-    return str;
-  }
-  return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
-};
 
-export const skipTrimToSentenceCase = (str: string): string => {
+export const transformToSentenceCase = (str: string): string => {
   if (!str) {
     return str;
   }
@@ -19,5 +16,5 @@ export const skipTrimToSentenceCase = (str: string): string => {
   if (firstCharIndex === -1) {
     return str;
   }
-  return str.slice(0, firstCharIndex) + toSentenceCase(str.slice(firstCharIndex));
+  return str.slice(0, firstCharIndex) + str.charAt(firstCharIndex).toUpperCase() + str.slice(firstCharIndex + 1).toLowerCase();
 };


### PR DESCRIPTION
# Summary

added two functions: a general uppercase to sentence case function and a special handling function to skip numbers or special characters for case transformation and trim space, e.g. only make alphabetic letters to sentence case once found

## Related Issues / Tickets

- Closes #5 

## Contributor info

- LinkedIn profile: [Kexin-Wei](https://www.linkedin.com/in/kexin-wei-611s96/)

## Type of change

- [ ] Fix (non-breaking change that fixes an issue)
- [x] Feature (non-breaking change that adds functionality)
- [ ] Refactor (no functional change)
- [ ] Chore/Docs/Build
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How to Test
edit `src/data/locations.json`  
```json
  {
    "building": "ION ORCHARD MALL",
    "block": 2,
    "road": "ORCHARD TURN",
    "address": "2 ORCHARD TURN, SINGAPORE 238801",
    "postalCode": "238801",
    "latitude": 1.3040,
    "longitude": 103.8318,
    "opensAt": "09:00:00",
    "closesAt": "19:00:00"
  },

```
and check in the frontend

```bash
npm install
npm run db:fresh:local
npm run dev
```

## Screenshots / Recordings

N.A.

## Checklist

- [x] I ran the app locally and verified the change
- [x] I added/updated tests as needed
- [x] I updated documentation (README, comments, or storybook) as needed
- [ ] I updated environment docs if env vars changed
- [x] No sensitive info (keys, tokens) is committed
- [ ] Database migration required (see “Database Migration” section)

## Breaking Changes

N.A.

## Database Migration

N.A.

## Deployment Notes

N.A.

## Environment Changes

N.A.

## Additional Context

N.A.