### PR TITLE
chore: enhance CI workflow for forked PRs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,8 +11,6 @@ jobs:
     strategy:
       matrix:
         node-version: [20.x, 22.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     name: Build with ${{ matrix.node-version }}
     runs-on: ubuntu-latest
     environment: staging
@@ -27,6 +25,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      # If this is a PR from a fork, secrets (including environment secrets) are not available.
+      # Skip this secret-dependent build for forked PRs to avoid zod validation errors.
+      - name: Detect fork PR and skip secret-required build
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        run: |
+          echo "This PR is from a fork. Environment secrets are not available; skipping secret-dependent build steps."
+          exit 0
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -39,7 +46,6 @@ jobs:
     strategy:
       matrix:
         node-version: [20.x]
-
     name: Run all tests
     runs-on: ubuntu-latest
     environment: staging
@@ -56,6 +62,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Retrieve Git history, needed to verify commits
+
+      - name: Detect fork PR (for conditional steps)
+        id: detect_fork
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "is_fork=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_fork=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -63,7 +79,9 @@ jobs:
           cache: npm
       - run: npm ci
 
+      # Build Next.js for E2E tests and run E2E only when NOT a fork PR (these steps require secrets)
       - name: Build Next.js for E2E tests
+        if: steps.detect_fork.outputs.is_fork == 'false'
         run: npm run build
 
       - if: github.event_name == 'pull_request'
@@ -79,18 +97,12 @@ jobs:
       - name: Run unit tests
         run: npm run test -- --coverage
 
-      # - name: Upload coverage reports to Codecov
-      #   uses: codecov/codecov-action@v5
-      #   env:
-      #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
       - name: Install Playwright (used for Storybook and E2E tests)
         run: npx playwright install --with-deps
 
-      # - name: Run storybook tests
-      #   run: npm run test-storybook:ci
-
+      # Run E2E (and Percy) only when NOT a fork PR
       - name: Run E2E tests
+        if: steps.detect_fork.outputs.is_fork == 'false'
         run: npx percy exec -- npm run test:e2e
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}


### PR DESCRIPTION
# Summary
Added conditional steps for forked pull requests and improved workflow structure.

- Skip secret-dependent build steps for pull requests opened from forked repositories so environment secrets (e.g. NEXT_PUBLIC_CLERK_SIGN_IN_URL) are not required during those runs.
- This prevents zod validation failures in src/libs/Env.ts when secrets are unavailable for fork PRs.

## Why

- GitHub does not expose repository or environment secrets to workflows running untrusted code from forks. The validation in src/libs/Env.ts (see file) requires NEXT_PUBLIC_CLERK_SIGN_IN_URL to be non-empty, causing builds for fork PRs to fail with:
 - "String must contain at least 1 character(s)" for NEXT_PUBLIC_CLERK_SIGN_IN_URL
 - Error thrown at src/libs/Env.ts:13
 - See: src/libs/Env.ts (ref: 42fde5fa02a43867bac51e69de72c575b94c6d7b)

## Change summary
- Add early detection for fork PRs in the CI workflow and:
 - For the build job: print a message and exit before running secret-dependent steps.
 - For the test job: set a detect_fork output and conditionally skip build/E2E/percy steps that require secrets.
- Keep linting, type-checking, and unit tests running for fork PRs.

## Files changed
- .github/workflows/CI.yml
 - Add "Detect fork PR" steps and if: conditions to skip secret-dependent steps.

## Related Issues / Tickets
- Closes #46 
- Related to #41 

## Type of change

- [x] Fix (non-breaking change that fixes an issue)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Refactor (no functional change)
- [x] Chore/Docs/Build
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How to Validate (REQUIRES MERGE TO MAIN FIRST)
- For a fork PR: the workflow should exit the secret-dependent build early and still run lint/typecheck/unit tests.
- For branches inside this repo or pushes to main: the full workflow still runs and has access to secrets.

### Why merge-first is recommended

GitHub uses the workflow file from the base repository for PR runs in order to avoid executing untrusted workflow changes. To exercise the modified workflow for fork PRs you need the updated workflow present in the base repo (main) that the PR targets.

## Rollback plan

Revert the workflow change if any unexpected side effects are seen. 

## Checklist

 - [ ] Confirm .github/workflows/CI.yml contains the fork-detection steps
 - [ ] Validate a test PR from a fork (should skip secret-dependent steps)
 - [ ] Validate a branch PR from within repo (should run full CI)

## Checklist

- [ ] I ran the app locally and verified the change
- [ ] I added/updated tests as needed
- [ ] I updated documentation (README, comments, or storybook) as needed
- [ ] I updated environment docs if env vars changed
- [x] No sensitive info (keys, tokens) is committed
- [ ] Database migration required (see “Database Migration” section)
